### PR TITLE
Image has wrong colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 > GitHub's official light syntax theme as an atom theme
 
-![](https://cloud.githubusercontent.com/assets/54012/16179343/c0a78672-3630-11e6-80b1-eb0a0b647225.png)
 
 ## Install
 


### PR DESCRIPTION
The image shouldn't be removed, I'm just pointing out that the colors in the image aren't the actual GitHub colors.

However, after trying the plugin, the colors in Atom _are_ correct.

Updating the image might prevent some people from not installing, thinking the colors aren't exactly like GitHub's. I was almost one such person.